### PR TITLE
Add description as caption in lightgallery dialog and below image

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This will Output :
 <p>
   <div class="lightgallery">
     <a href="../img/pic1.png">
-      <img alt="!Description" src="../img/pic1.png" />
+      <img alt="Description" src="../img/pic1.png" />
     </a>
   </div>
 </p>
@@ -110,7 +110,6 @@ All settings of the extension are optional and can be omitted.
 # Extensions
 markdown_extensions:
   - lightgallery:
-      strip_leading_exclamation_mark: true | false
       show_description_in_lightgallery: true | false
       show_description_as_inline_caption: true | false
       custom_inline_caption_css_class: 'my-caption-class'
@@ -118,7 +117,6 @@ markdown_extensions:
 
 | Setting | Description | Default Value |
 |-|-|-|
-| `strip_leading_exclamation_mark` | Strips the leading exclamation mark from description. | `false` |
 | `show_description_in_lightgallery` | Adds the description as caption in lightgallery dialog. | `false` |
 | `show_description_as_inline_caption` | Adds the description as inline caption below the image. | `false` |
 | `custom_inline_caption_css_class` | Custom CSS classes which are applied to the inline caption paragraph. Multiple classes are separated via space. | Empty |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ markdown_extensions:
   - lightgallery
 ```
 
+**5.** Change extension settings in **mkdocs.yml**
+
+All settings of the extension are optional and can be omitted.
+
+```
+# Extensions
+markdown_extensions:
+  - lightgallery:
+      strip_leading_exclamation_mark: true | false
+      show_description_in_lightgallery: true | false
+      show_description_as_inline_caption: true | false
+      custom_inline_caption_css_class: 'my-caption-class'
+```
+
+| Setting | Description | Default Value |
+|-|-|-|
+| `strip_leading_exclamation_mark` | Strips the leading exclamation mark from description. | `false` |
+| `show_description_in_lightgallery` | Adds the description as caption in lightgallery dialog. | `false` |
+| `show_description_as_inline_caption` | Adds the description as inline caption below the image. | `false` |
+| `custom_inline_caption_css_class` | Custom CSS classes which are applied to the inline caption paragraph. Multiple classes are separated via space. | Empty |
+
+
 ## License
 
 MIT License

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This will Output :
 ```html
 <p>
   <div class="lightgallery">
-    <a href="../img/pic1.png">
+    <a href="../img/pic1.png" data-sub-html="Description">
       <img alt="Description" src="../img/pic1.png" />
     </a>
   </div>
@@ -117,7 +117,7 @@ markdown_extensions:
 
 | Setting | Description | Default Value |
 |-|-|-|
-| `show_description_in_lightgallery` | Adds the description as caption in lightgallery dialog. | `false` |
+| `show_description_in_lightgallery` | Adds the description as caption in lightgallery dialog. | `true` |
 | `show_description_as_inline_caption` | Adds the description as inline caption below the image. | `false` |
 | `custom_inline_caption_css_class` | Custom CSS classes which are applied to the inline caption paragraph. Multiple classes are separated via space. | Empty |
 

--- a/lightgallery.py
+++ b/lightgallery.py
@@ -18,7 +18,7 @@ class ImagesTreeprocessor(Treeprocessor):
             if self.re.match(desc):
                 if self.config["strip_leading_exclamation_mark"]:
                     desc = desc.lstrip("!")
-            
+
                 image.set("alt", desc)
                 parent = parent_map[image]
                 ix = list(parent).index(image)
@@ -26,6 +26,10 @@ class ImagesTreeprocessor(Treeprocessor):
                 div_node.set("class", "lightgallery")
                 new_node = etree.Element('a')
                 new_node.set("href", image.attrib["src"])
+
+                if self.config["show_description_in_lightgallery"]:
+                    new_node.set("data-sub-html", desc)
+
                 new_node.append(image)
                 div_node.append(new_node)
                 parent.insert(ix, div_node)
@@ -35,7 +39,8 @@ class ImagesTreeprocessor(Treeprocessor):
 class LightGalleryExtension(Extension):
     def __init__(self, **kwargs):
         self.config = {
-            'strip_leading_exclamation_mark' : [False, 'Strip leading exclamation mark from description. Default: False']
+            'strip_leading_exclamation_mark' : [False, 'Strip leading exclamation mark from description. Default: False'],
+            'show_description_in_lightgallery' : [False, 'Show description as caption in lightgallery. Default: False']
         }
         super(LightGalleryExtension, self).__init__(**kwargs)
 

--- a/lightgallery.py
+++ b/lightgallery.py
@@ -42,7 +42,7 @@ class ImagesTreeprocessor(Treeprocessor):
 class LightGalleryExtension(Extension):
     def __init__(self, **kwargs):
         self.config = {
-            'show_description_in_lightgallery' : [False, 'Adds the description as caption in lightgallery dialog. Default: False'],
+            'show_description_in_lightgallery' : [True, 'Adds the description as caption in lightgallery dialog. Default: True'],
             'show_description_as_inline_caption' : [False, 'Adds the description as inline caption below the image. Default: False'],
             'custom_inline_caption_css_class' : ['', 'Custom CSS classes which are applied to the inline caption paragraph. Multiple classes are separated via space. Default: empty']
         }

--- a/lightgallery.py
+++ b/lightgallery.py
@@ -35,12 +35,19 @@ class ImagesTreeprocessor(Treeprocessor):
                 parent.insert(ix, div_node)
                 parent.remove(image)
 
+                if self.config["show_description_as_inline_caption"]:
+                    inline_caption_node = etree.Element('p')
+                    inline_caption_node.set("class", self.config["custom_inline_caption_css_class"])
+                    inline_caption_node.text = desc
+                    parent.insert(ix + 1, inline_caption_node)
 
 class LightGalleryExtension(Extension):
     def __init__(self, **kwargs):
         self.config = {
             'strip_leading_exclamation_mark' : [False, 'Strip leading exclamation mark from description. Default: False'],
-            'show_description_in_lightgallery' : [False, 'Show description as caption in lightgallery. Default: False']
+            'show_description_in_lightgallery' : [False, 'Show description as caption in lightgallery. Default: False'],
+            'show_description_as_inline_caption' : [False, 'Show description as inline caption below the image. Default: False'],
+            'custom_inline_caption_css_class' : ['', 'Custom CSS classes which are applied to the inline caption paragraph. Multiple classes to be separated via space. Default: empty']
         }
         super(LightGalleryExtension, self).__init__(**kwargs)
 

--- a/lightgallery.py
+++ b/lightgallery.py
@@ -44,10 +44,10 @@ class ImagesTreeprocessor(Treeprocessor):
 class LightGalleryExtension(Extension):
     def __init__(self, **kwargs):
         self.config = {
-            'strip_leading_exclamation_mark' : [False, 'Strip leading exclamation mark from description. Default: False'],
-            'show_description_in_lightgallery' : [False, 'Show description as caption in lightgallery. Default: False'],
-            'show_description_as_inline_caption' : [False, 'Show description as inline caption below the image. Default: False'],
-            'custom_inline_caption_css_class' : ['', 'Custom CSS classes which are applied to the inline caption paragraph. Multiple classes to be separated via space. Default: empty']
+            'strip_leading_exclamation_mark' : [False, 'Strips the leading exclamation mark from description. Default: False'],
+            'show_description_in_lightgallery' : [False, 'Adds the description as caption in lightgallery dialog. Default: False'],
+            'show_description_as_inline_caption' : [False, 'Adds the description as inline caption below the image. Default: False'],
+            'custom_inline_caption_css_class' : ['', 'Custom CSS classes which are applied to the inline caption paragraph. Multiple classes are separated via space. Default: empty']
         }
         super(LightGalleryExtension, self).__init__(**kwargs)
 

--- a/lightgallery.py
+++ b/lightgallery.py
@@ -16,9 +16,7 @@ class ImagesTreeprocessor(Treeprocessor):
         for image in images:
             desc = image.attrib["alt"]
             if self.re.match(desc):
-                if self.config["strip_leading_exclamation_mark"]:
-                    desc = desc.lstrip("!")
-
+                desc = desc.lstrip("!")
                 image.set("alt", desc)
                 parent = parent_map[image]
                 ix = list(parent).index(image)
@@ -44,7 +42,6 @@ class ImagesTreeprocessor(Treeprocessor):
 class LightGalleryExtension(Extension):
     def __init__(self, **kwargs):
         self.config = {
-            'strip_leading_exclamation_mark' : [False, 'Strips the leading exclamation mark from description. Default: False'],
             'show_description_in_lightgallery' : [False, 'Adds the description as caption in lightgallery dialog. Default: False'],
             'show_description_as_inline_caption' : [False, 'Adds the description as inline caption below the image. Default: False'],
             'custom_inline_caption_css_class' : ['', 'Custom CSS classes which are applied to the inline caption paragraph. Multiple classes are separated via space. Default: empty']


### PR DESCRIPTION
Hi Gauthier,

as discussed via mail, please find enclosed the suggested changes:
- to remove the ! from description text
- to show description as caption in lightgallery - enabled by default
- to show description as inline-caption below the image - disabled by default

Please let me know if further adjustments are needed or if you are facing any problems during testing. I have tested against my own documentation project using mkdocs & mkdocs-material theme successfully.

Best regards,
Stefan