### PR TITLE
Add Ability To Publish Package On PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: publish
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build_and_publish:
+    name: Build and Publish Package on PyPI
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+
+      - name: Install Python Build Dependencies
+        run: pip install --upgrade setuptools wheel twine
+
+      - name: Build lightgallery-markdown Package
+        run: python setup.py build sdist bdist_wheel --universal
+
+      - name: Publish to PyPI
+        if: github.repository == 'g-provost/lightgallery.markdown'
+        env:
+          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: twine upload --disable-progress-bar -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 build/
 dist/
 lightgallery.egg-info/
+
+#Eclipse Artifacts
+.project
+.settings 

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ lightgallery.egg-info/
 
 #Eclipse Artifacts
 .project
-.settings 
+.settings

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,11 @@ setup(
     py_modules=['lightgallery'],
     install_requires = ['markdown>=3.0'],
     classifiers=['Topic :: Text Processing :: Markup :: HTML'],
-    license='MIT License'
+    license='MIT License',
+    url='https://github.com/g-provost/lightgallery-markdown',
+    project_urls={
+        'Source': 'https://github.com/g-provost/lightgallery-markdown',
+        'Documentation': 'https://github.com/g-provost/lightgallery-markdown',
+        'Tracker': 'https://github.com/g-provost/lightgallery-markdown/issues'
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,22 @@
 from setuptools import setup
+from os import path
 
+# Read the content of the README.md file as long_description
+root_directory = path.abspath(path.dirname(__file__))
+with open(path.join(root_directory, 'README.md'), encoding='utf-8') as readme_file:
+    readme_content = readme_file.read() 
+
+# Package Definition
 setup(
     name='lightgallery',
     version='0.1.2',
     author='Gauthier Provost',
     author_email='gauthier@kobol.io',
     description='Markdown extension to wrap images in lightbox/lightgallery',
+    long_description=readme_content,
+    long_description_content_type='text/markdown; charset=UTF-8; variant=GFM',
     py_modules=['lightgallery'],
     install_requires = ['markdown>=3.0'],
     classifiers=['Topic :: Text Processing :: Markup :: HTML'],
-    license='MIT License',
+    license='MIT License'
 )


### PR DESCRIPTION
Hi @g-provost,

sorry that it took so long to work on #3. I have created a simple Github Actions script which will publish the package automatically any time that a release is published on Github. I have also enhanced a few metadata settings of the setup script.

To make the publish script run properly, you will need an API token to communicate with pypi.org. If you don't have ab account there already, you can [register for free](https://pypi.org/account/register/). Once you have validated the used email address, you can create an API token and maintain it in Github:
1. On pypi.org go to `Account Settings` --> `API Tokens`  --> `Add API token`.
2. Provide a `Token name` and select the only available `Scope` and choose `Add token`.
3. Take note of the token value for later reference. You maybe want to store it in a password manager of your choice for later reference as the token is only displayed this one time.
4. Now switch to the Gitub Repo and go to `Settings` -> `Secrets` and add two repository secrets by choosing `New repository secret`:
    - `PYPI_USERNAME` with value `__token__`
    - `PYPI_PASSWORD` with the token value that you have copied from pypi.org

The settings to run the script are now in place. To trigger the script, you need to create a release on github based on an existing tag or by creating a new tag on Github for the last commit.

Once you click `Publish release`, the script starts to run and uploads the new version of the package to pypi.org.

The release text could also contain a short set of information about the changes (new featuers / bug fixes / ...) and maybe a compare URL between release tags. This way users can also follow whats changed between releases easily.

Hope this suits the requirement.

BR, Stefan